### PR TITLE
Use quotes around $escape_metachar in escCharList

### DIFF
--- a/txt2regex.sh
+++ b/txt2regex.sh
@@ -1206,7 +1206,11 @@ escCharList() {
     # shellcheck disable=SC1003
     if [ "$(getMeta "ax_${progs[$1]}" 6)" == '\' ]; then
         escape_metachar=$(getMeta "ax_${progs[$1]}" 4)
-        uin="${uin/\\/$escape_metachar$escape_metachar}"
+        if [[ ${BASH_VERSINFO[0]} -lt 5 ]]; then
+            uin="${uin/\\/$escape_metachar$escape_metachar}"
+        else
+            uin="${uin/\\/"$escape_metachar$escape_metachar"}"
+        fi
     fi
 }
 


### PR DESCRIPTION
The expression uin="${uin/\\/$escape_metachar$escape_metachar}" has
different output on bash 5.2 then on earlier versions. Namely,
$escape_metachar is not treated as a string literal, so the escape
characters are applied which results in half as many escape chars in the
output:

  $ bash --version | head -1
  GNU bash, version 5.2.0(1)-rc2 (x86_64-pc-linux-gnu)
  $ uin='[\]'; escape_metachar='\\'; echo ${uin/\\/$escape_metachar$escape_metachar}
  [\\]

  vs.

  $ bash --version | head -1
  GNU bash, version 5.1.16(1)-release (x86_64-pc-linux-gnu)
  $ uin='[\]'; escape_metachar='\\'; echo ${uin/\\/$escape_metachar$escape_metachar}
  [\\\\]

To fix this, add quotes around $escape_metachar in this substitution,
which works on bash 5.2 as well as earlier versions:

  $ bash --version | head -1
  GNU bash, version 5.2.0(1)-rc2 (x86_64-pc-linux-gnu)
  $ uin='[\]'; escape_metachar='\\'; echo ${uin/\\/"$escape_metachar$escape_metachar"}
  [\\\\]

  and

  $ bash --version | head -1
  GNU bash, version 5.1.16(1)-release (x86_64-pc-linux-gnu)
  $ uin='[\]'; escape_metachar='\\'; echo ${uin/\\/"$escape_metachar$escape_metachar"}
  [\\\\]