### PR TITLE
CI: Use Ubuntu 22.04 to fix SIGPIPE issue

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,17 +7,19 @@ on:
 jobs:
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - run: sudo snap install shfmt
       - run: make lint
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
-      - run: make test
+      # See https://github.com/aureliojargas/txt2regex/pull/9 on why we're
+      # using env in the next command
+      - run: env --default-signal=PIPE make test
       - run: make test-bash
       - run: make test-regex
 

--- a/tests/cmdline.md
+++ b/tests/cmdline.md
@@ -381,7 +381,7 @@ $
 ## Invalid option
 
 ```console
-$ txt2regex --foo > usage; head -n 3 usage | sed '3 s/:.*//'; rm usage
+$ txt2regex --foo | head -n 3 | sed '3 s/:.*//'
 --foo: invalid option
 
 usage


### PR DESCRIPTION
With the new `--default-signal` in the `env` command we can fix the
issue with SIGPIPE being trapped, when running in GitHub Actions.
    
Please refer to PR #9 for detailed information on this issue.